### PR TITLE
Add analysis tools for DeepMD dataset sketch maps

### DIFF
--- a/examples/analysis/common.py
+++ b/examples/analysis/common.py
@@ -1,0 +1,128 @@
+"""Utility helpers for analyzing Deep Potential datasets with dpeva."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+import numpy as np
+import dpdata
+from deepmd.infer.deep_pot import DeepPot
+
+
+@dataclass
+class DatasetBundle:
+    """Container for the raw arrays used in descriptor analysis."""
+
+    system: dpdata.LabeledSystem
+    coords: np.ndarray
+    cells: np.ndarray
+    energies: np.ndarray
+    atom_types: List[int]
+    type_symbols: List[str]
+
+    @property
+    def n_frames(self) -> int:
+        """Return the number of frames in the dataset."""
+
+        return int(self.coords.shape[0])
+
+    @property
+    def n_atoms(self) -> int:
+        """Return the number of atoms per frame."""
+
+        return int(self.coords.shape[1])
+
+
+def load_deepmd_dataset(dataset_path: Path | str) -> DatasetBundle:
+    """Load a DeepMD training set from ``dataset_path``.
+
+    Parameters
+    ----------
+    dataset_path:
+        Path to the directory containing ``set.*`` folders and ``type.raw``.
+
+    Returns
+    -------
+    DatasetBundle
+        Object containing the raw arrays and metadata extracted from the dataset.
+    """
+
+    dataset = dpdata.LabeledSystem(str(dataset_path), fmt="deepmd/npy")
+    coords = np.asarray(dataset.data["coords"], dtype=np.float64)
+    cells = np.asarray(dataset.data["cells"], dtype=np.float64)
+    energies = np.asarray(dataset.data["energies"], dtype=np.float64)
+
+    atom_types = list(map(int, dataset.get_atom_types()))
+    type_symbols = list(dataset.get_atom_names())
+
+    return DatasetBundle(
+        system=dataset,
+        coords=coords,
+        cells=cells,
+        energies=energies,
+        atom_types=atom_types,
+        type_symbols=type_symbols,
+    )
+
+
+def build_model_type_indices(dataset: DatasetBundle, model: DeepPot) -> List[int]:
+    """Map dataset atom types to the ordering expected by the model."""
+
+    model_type_map = list(model.get_type_map())
+    index_lookup = {symbol: model_type_map.index(symbol) for symbol in dataset.type_symbols}
+    mapped = [index_lookup[dataset.type_symbols[idx]] for idx in dataset.atom_types]
+    return mapped
+
+
+def batched(iterable: np.ndarray, batch_size: int) -> Iterable[tuple[int, int]]:
+    """Yield (start, stop) indices that split an array into batches."""
+
+    total = int(iterable.shape[0])
+    for start in range(0, total, batch_size):
+        stop = min(total, start + batch_size)
+        yield start, stop
+
+
+def evaluate_descriptors(
+    dataset: DatasetBundle,
+    model: DeepPot,
+    batch_size: int = 32,
+) -> np.ndarray:
+    """Evaluate descriptors for the provided dataset using ``model``.
+
+    Parameters
+    ----------
+    dataset:
+        Loaded DeepMD dataset.
+    model:
+        Frozen Deep Potential model.
+    batch_size:
+        Number of frames evaluated per batch. ``32`` is a reasonable default
+        for most CPU-bound environments.
+
+    Returns
+    -------
+    numpy.ndarray
+        Array with shape ``(n_frames, n_atoms, descriptor_dim)`` containing the
+        descriptor of every atom in every frame.
+    """
+
+    mapped_types = build_model_type_indices(dataset, model)
+
+    descriptor_frames: list[np.ndarray] = []
+    for start, stop in batched(dataset.coords, batch_size):
+        cells = dataset.cells[start:stop]
+        if cells.ndim == 3 and cells.shape[-2:] == (3, 3):
+            cells_batch = cells
+        else:
+            cells_batch = cells.reshape(-1, 3, 3)
+
+        desc = model.eval_descriptor(
+            dataset.coords[start:stop],
+            cells_batch,
+            mapped_types,
+        )
+        descriptor_frames.append(desc)
+
+    return np.concatenate(descriptor_frames, axis=0)

--- a/examples/analysis/generate_descriptors.py
+++ b/examples/analysis/generate_descriptors.py
@@ -1,0 +1,128 @@
+"""Generate descriptors for a Deep Potential training dataset."""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from deepmd.infer.deep_pot import DeepPot
+
+from .common import evaluate_descriptors, load_deepmd_dataset
+
+
+def parse_arguments() -> argparse.Namespace:
+    """Build the command line parser."""
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Evaluate the descriptors learned by a Deep Potential model for a "
+            "training dataset stored in DeepMD's numpy format."
+        )
+    )
+    parser.add_argument(
+        "dataset",
+        type=Path,
+        help="Path to the DeepMD dataset directory (contains set.* folders).",
+    )
+    parser.add_argument(
+        "model",
+        type=Path,
+        help="Path to the frozen_model.pb file produced by deepmd-kit.",
+    )
+    parser.add_argument(
+        "output",
+        type=Path,
+        help="Directory where descriptor arrays and metadata will be stored.",
+    )
+    parser.add_argument(
+        "--head",
+        default=None,
+        help=(
+            "Optional name of the model head to use when the graph exports "
+            "multiple outputs (for example: Target_FTS)."
+        ),
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=32,
+        help="Number of frames evaluated together when calling the model.",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Allow overwriting existing descriptor files in the output directory.",
+    )
+    return parser.parse_args()
+
+
+def ensure_output_directory(path: Path, overwrite: bool) -> None:
+    """Prepare the output directory while respecting the overwrite flag."""
+
+    path.mkdir(parents=True, exist_ok=True)
+    descriptor_path = path / "descriptor_frames.npy"
+    if descriptor_path.exists() and not overwrite:
+        raise FileExistsError(
+            f"Descriptor file {descriptor_path} already exists. "
+            "Use --overwrite to regenerate the descriptors."
+        )
+
+
+def save_metadata(output_dir: Path, dataset_info: dict[str, Any]) -> None:
+    """Persist auxiliary metadata as a JSON file for reproducibility."""
+
+    metadata_path = output_dir / "descriptor_metadata.json"
+    with metadata_path.open("w", encoding="utf-8") as handle:
+        json.dump(dataset_info, handle, indent=2)
+
+
+
+def main() -> None:
+    args = parse_arguments()
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+    ensure_output_directory(args.output, args.overwrite)
+
+    logging.info("Loading dataset from %s", args.dataset)
+    dataset = load_deepmd_dataset(args.dataset)
+
+    logging.info("Loading model graph from %s", args.model)
+    model = DeepPot(str(args.model), head=args.head)
+
+    logging.info("Evaluating descriptors in batches of %d frames", args.batch_size)
+    descriptor_frames = evaluate_descriptors(dataset, model, batch_size=args.batch_size)
+    logging.info("Descriptor tensor shape: %s", descriptor_frames.shape)
+
+    descriptor_path = args.output / "descriptor_frames.npy"
+    np.save(descriptor_path, descriptor_frames)
+    logging.info("Descriptor tensor saved to %s", descriptor_path)
+
+    mean_descriptor = descriptor_frames.mean(axis=1)
+    energies_per_atom = dataset.energies / dataset.n_atoms
+
+    summary_path = args.output / "descriptor_summary.npz"
+    np.savez_compressed(
+        summary_path,
+        mean_descriptor=mean_descriptor,
+        energy_per_atom=energies_per_atom,
+    )
+    logging.info("Descriptor summary saved to %s", summary_path)
+
+    metadata = {
+        "dataset": str(args.dataset.resolve()),
+        "model": str(args.model.resolve()),
+        "n_frames": dataset.n_frames,
+        "n_atoms": dataset.n_atoms,
+        "descriptor_shape": descriptor_frames.shape,
+        "head": args.head,
+        "batch_size": args.batch_size,
+    }
+    save_metadata(args.output, metadata)
+    logging.info("Metadata written to descriptor_metadata.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/analysis/plot_sketch_map.py
+++ b/examples/analysis/plot_sketch_map.py
@@ -1,0 +1,238 @@
+"""Create a sketch map of training data using descriptors from a DP model."""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Sequence, Tuple
+
+import numpy as np
+import pandas as pd
+import seaborn as sns
+from ase import Atoms
+from ase.io import write
+from deepmd.infer.deep_pot import DeepPot
+from matplotlib import pyplot as plt
+from sklearn.decomposition import PCA
+
+from .common import evaluate_descriptors, load_deepmd_dataset
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build a PCA-based sketch map of a DeepMD training set using the "
+            "descriptors from a frozen Deep Potential model."
+        )
+    )
+    parser.add_argument(
+        "dataset",
+        type=Path,
+        help="Path to the DeepMD dataset directory (contains set.* folders).",
+    )
+    parser.add_argument(
+        "model",
+        type=Path,
+        help="Path to the frozen_model.pb file used for inference.",
+    )
+    parser.add_argument(
+        "output",
+        type=Path,
+        help="Directory used to store the generated sketch map and samples.",
+    )
+    parser.add_argument(
+        "--head",
+        default=None,
+        help="Optional head name if the graph exposes multiple outputs.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=32,
+        help="Number of frames evaluated in parallel when computing descriptors.",
+    )
+    parser.add_argument(
+        "--sample-count",
+        type=int,
+        default=4,
+        help="Number of representative structures to export as XYZ files.",
+    )
+    parser.add_argument(
+        "--random-state",
+        type=int,
+        default=0,
+        help="Random seed for the PCA algorithm.",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Regenerate all results even if they already exist in the output directory.",
+    )
+    return parser.parse_args()
+
+
+def prepare_output_directory(path: Path, overwrite: bool) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    if any(path.iterdir()) and not overwrite:
+        logging.warning(
+            "Output directory %s is not empty. Existing files may be reused.", path
+        )
+
+
+def compute_pca_embedding(data: np.ndarray, random_state: int) -> np.ndarray:
+    reducer = PCA(n_components=2, random_state=random_state)
+    return reducer.fit_transform(data)
+
+
+def export_samples(
+    dataset_coords: np.ndarray,
+    dataset_cells: np.ndarray,
+    atom_symbols: Sequence[str],
+    atom_types: Sequence[int],
+    frame_indices: Sequence[Tuple[str, int]],
+    destination: Path,
+) -> None:
+    """Write representative structures to ``destination`` as XYZ files."""
+
+    destination.mkdir(parents=True, exist_ok=True)
+    symbols = [atom_symbols[idx] for idx in atom_types]
+
+    for label, frame_index in frame_indices:
+        atoms = Atoms(
+            symbols=symbols,
+            positions=dataset_coords[frame_index],
+            cell=dataset_cells[frame_index],
+            pbc=True,
+        )
+        file_path = destination / f"sample_{label}_{frame_index:05d}.xyz"
+        write(file_path, atoms)
+        logging.info("Exported %s", file_path)
+
+
+def select_representative_frames(embedding: np.ndarray, count: int) -> list[tuple[str, int]]:
+    """Select frames from extreme regions of the embedding."""
+
+    indices = {
+        "pc1_min": int(np.argmin(embedding[:, 0])),
+        "pc1_max": int(np.argmax(embedding[:, 0])),
+        "pc2_min": int(np.argmin(embedding[:, 1])),
+        "pc2_max": int(np.argmax(embedding[:, 1])),
+    }
+
+    selected: list[tuple[str, int]] = list(indices.items())
+
+    remaining = count - len(selected)
+    if remaining > 0:
+        additional = np.linspace(0, embedding.shape[0] - 1, remaining, dtype=int)
+        for idx, frame in enumerate(additional):
+            selected.append((f"extra{idx}", int(frame)))
+
+    seen = set()
+    unique_selection = []
+    for label, frame_index in selected:
+        if frame_index in seen:
+            continue
+        seen.add(frame_index)
+        unique_selection.append((label, frame_index))
+    return unique_selection[:count]
+
+
+def create_sketch_map(
+    dataset_dir: Path,
+    model_path: Path,
+    output_dir: Path,
+    head: str | None,
+    batch_size: int,
+    sample_count: int,
+    random_state: int,
+    overwrite: bool,
+) -> None:
+    logging.info("Loading dataset from %s", dataset_dir)
+    dataset = load_deepmd_dataset(dataset_dir)
+
+    logging.info("Loading model graph from %s", model_path)
+    model = DeepPot(str(model_path), head=head)
+
+    descriptor_cache = output_dir / "descriptor_frames.npy"
+    if descriptor_cache.exists() and not overwrite:
+        logging.info("Reusing cached descriptors from %s", descriptor_cache)
+        descriptor_frames = np.load(descriptor_cache)
+    else:
+        logging.info("Evaluating descriptors (batch size: %d)", batch_size)
+        descriptor_frames = evaluate_descriptors(dataset, model, batch_size=batch_size)
+        np.save(descriptor_cache, descriptor_frames)
+        logging.info("Descriptor tensor saved to %s", descriptor_cache)
+
+    mean_descriptor = descriptor_frames.mean(axis=1)
+    energy_per_atom = dataset.energies / dataset.n_atoms
+
+    logging.info("Performing PCA to obtain the sketch map")
+    embedding = compute_pca_embedding(mean_descriptor, random_state=random_state)
+
+    df = pd.DataFrame(
+        {
+            "pc1": embedding[:, 0],
+            "pc2": embedding[:, 1],
+            "energy_per_atom": energy_per_atom,
+            "frame_index": np.arange(dataset.n_frames),
+        }
+    )
+
+    csv_path = output_dir / "sketch_map_points.csv"
+    df.to_csv(csv_path, index=False)
+    logging.info("Stored PCA embedding coordinates in %s", csv_path)
+
+    plt.figure(figsize=(10, 8))
+    sns.scatterplot(
+        data=df,
+        x="pc1",
+        y="pc2",
+        hue="energy_per_atom",
+        palette="viridis",
+        s=60,
+        alpha=0.8,
+    )
+    plt.title("Sketch map of training structures")
+    plt.xlabel("Principal Component 1")
+    plt.ylabel("Principal Component 2")
+    plt.legend(title="Energy per atom", loc="best")
+    plt.tight_layout()
+
+    figure_path = output_dir / "sketch_map.png"
+    plt.savefig(figure_path, dpi=300)
+    plt.close()
+    logging.info("Sketch map saved to %s", figure_path)
+
+    sample_dir = output_dir / "structures"
+    selection = select_representative_frames(embedding, sample_count)
+    export_samples(
+        dataset.coords,
+        dataset.cells,
+        dataset.type_symbols,
+        dataset.atom_types,
+        selection,
+        sample_dir,
+    )
+
+    selection_path = output_dir / "selected_frames.json"
+    with selection_path.open("w", encoding="utf-8") as handle:
+        json_dump = {label: int(index) for label, index in selection}
+        json.dump(json_dump, handle, indent=2)
+    logging.info("Sample metadata stored in %s", selection_path)
+
+
+if __name__ == "__main__":
+    args = parse_arguments()
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    prepare_output_directory(args.output, args.overwrite)
+    create_sketch_map(
+        dataset_dir=args.dataset,
+        model_path=args.model,
+        output_dir=args.output,
+        head=args.head,
+        batch_size=args.batch_size,
+        sample_count=args.sample_count,
+        random_state=args.random_state,
+        overwrite=args.overwrite,
+    )


### PR DESCRIPTION
## Summary
- add reusable helpers to load DeepMD training sets and evaluate descriptors from frozen models
- provide a CLI script to generate descriptor tensors, summaries, and metadata for a dataset
- create a PCA sketch-map workflow that plots the dataset and exports representative structures

## Testing
- python -m compileall examples/analysis

------
https://chatgpt.com/codex/tasks/task_b_68e5f718ff48833096fe19131a70e86c